### PR TITLE
feat: support ssh urls

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -3,7 +3,7 @@ import { execa } from 'execa'
 export async function getGitHubRepo() {
   const res = await execa('git', ['config', '--get', 'remote.origin.url'])
   const url = String(res.stdout).trim()
-  const match = url.match(/github\.com\/([\w\d_-]+)\/([\w\d_-]+)(\.git)?$/i)
+  const match = url.match(/github\.com[\/:]([\w\d_-]+)\/([\w\d_-]+)(\.git)?$/i)
   if (!match)
     throw new Error(`Can not parse GitHub repo from url ${url}`)
   return `${match[1]}/${match[2]}`


### PR DESCRIPTION
This PR adds support for SSH URLs by tweaking the RegExp that parses the `origin` remote.  URLs such as `git@github.com:preset/preset.git` are now supported.