### PR TITLE
feat: new `capitalize` and `groupByScope` options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,8 @@ export async function resolveConfig(options: ChangelogOptions) {
         contributors: '❤️ Contributors',
       },
       contributors: true,
+      capitalize: true,
+      groupByScope: true,
     },
     overrides: options,
   })

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -2,16 +2,19 @@ import type { GitCommit } from 'changelogen'
 import { partition } from '@antfu/utils'
 import type { AuthorInfo, ResolvedChangelogOptions } from './types'
 
-function formatLine(commit: GitCommit, github: string) {
+function formatLine(commit: GitCommit, options: ResolvedChangelogOptions) {
   const refs = commit.references.map((r) => {
-    if (!github)
+    if (!options.github)
       return `\`${r}\``
     const url = r[0] === '#'
-      ? `https://github.com/${github}/issues/${r.slice(1)}`
-      : `https://github.com/${github}/commit/${r}`
+      ? `https://github.com/${options.github}/issues/${r.slice(1)}`
+      : `https://github.com/${options.github}/commit/${r}`
     return `[\`${r}\`](${url})`
   }).join(' ')
-  return `- ${capitalize(commit.description)} ${refs}`
+
+  return options.capitalize
+    ? `- ${capitalize(commit.description)} ${refs}`
+    : `- ${commit.description} ${refs}`
 }
 
 function formatTitle(name: string) {
@@ -35,7 +38,7 @@ function formatSection(commits: GitCommit[], sectionName: string, options: Resol
     }
     lines.push(...scopes[scope]
       .reverse()
-      .map(i => padding + formatLine(i, options.github)),
+      .map(i => padding + formatLine(i, options)),
     )
   })
   return lines

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -13,8 +13,8 @@ function formatLine(commit: GitCommit, options: ResolvedChangelogOptions) {
   }).join(' ')
 
   return options.capitalize
-    ? `- ${capitalize(commit.description)} ${refs}`
-    : `- ${commit.description} ${refs}`
+    ? `${capitalize(commit.description)} ${refs}`
+    : `${commit.description} ${refs}`
 }
 
 function formatTitle(name: string) {
@@ -29,18 +29,26 @@ function formatSection(commits: GitCommit[], sectionName: string, options: Resol
     formatTitle(sectionName),
     '',
   ]
+
   const scopes = groupBy(commits, 'scope')
   Object.keys(scopes).sort().forEach((scope) => {
     let padding = ''
-    if (scope) {
-      lines.push(`- **${options.scopeMap[scope] || scope}:**`)
+    let prefix = ''
+    const scopeText = `**${options.scopeMap[scope] || scope}**`
+    if (scope && options.groupByScope) {
+      lines.push(`- ${scopeText}:`)
       padding = '  '
     }
+    else if (scope) {
+      prefix = `${scopeText}: `
+    }
+
     lines.push(...scopes[scope]
       .reverse()
-      .map(i => padding + formatLine(i, options)),
+      .map(commit => `${padding}- ${prefix}${formatLine(commit, options)}`),
     )
   })
+
   return lines
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,11 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
    * @default true
    */
   capitalize?: boolean
+  /**
+   * Nest commit messages under their scopes
+   * @default true
+   */
+  groupByScope?: boolean
 }
 
 export type ResolvedChangelogOptions = Required<ChangelogOptions>

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,11 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
     breakingChanges?: string
     contributors?: string
   }
+  /**
+   * Capitalize commit messages
+   * @default true
+   */
+  capitalize?: boolean
 }
 
 export type ResolvedChangelogOptions = Required<ChangelogOptions>


### PR DESCRIPTION
This PR adds two new options. Their purpose is to be able to have an output more similar to `conventional-github-releaser`, which I personally like more (and I don't want to suddenly change the format of my releases).

- `capitalize`: determines if the commit messages should be capitalized
- `groupByScope`: determines if the commit messages should be nested under their scopes

Both options are true by default, so the current behavior is totally the same unless these options are defined to false.

---

<details>
<summary>Example on one of my projects so you don't have to test yourself</summary>

&nbsp;
**With both new options**
```
➜  node /Users/enzoinnocenzi/Code/forks/changelogithub/cli.mjs --dry --no-groupScopes --no-capitalize --from v0.2.0-beta.5

changelogithub v0.5.0
innocenzi/laravel-vite
v0.2.0-beta.5 -> v0.2.0-beta.21 (92 commits)
--------------

### 🚨 Breaking Changes

- add CSS and modulepreload tags for imported chunks [`#273`](https://github.com/innocenzi/laravel-vite/issues/273)

### 🚀 Features

- throw when getting a tag for a non-existing entrypoint [`8db9189`](https://github.com/innocenzi/laravel-vite/commit/8db9189)
- support multiple css file extensions in development [`#213`](https://github.com/innocenzi/laravel-vite/issues/213)
- do not update tsconfig in production by default [`281bc87`](https://github.com/innocenzi/laravel-vite/commit/281bc87)
- add `getEntryUrl` and `vite_entry_url` [`8f3ef9b`](https://github.com/innocenzi/laravel-vite/commit/8f3ef9b)
- make `Vite` and `Configuration` macroable [`35efb23`](https://github.com/innocenzi/laravel-vite/commit/35efb23)
- add `canAccessAssets` method [`b94dcb4`](https://github.com/innocenzi/laravel-vite/commit/b94dcb4)
- support @vite/plugin-legacy [`#259`](https://github.com/innocenzi/laravel-vite/issues/259)
- update default port to  `5173` [`b349c99`](https://github.com/innocenzi/laravel-vite/commit/b349c99)
- move from `tsup` to `unbuild` [`0d55aaa`](https://github.com/innocenzi/laravel-vite/commit/0d55aaa)
- **chunk**: expose asset url [`e772739`](https://github.com/innocenzi/laravel-vite/commit/e772739)
- **vite**: log config info when Vite starts [`d2e15d5`](https://github.com/innocenzi/laravel-vite/commit/d2e15d5)
- **vite**: add `watch` options [`a16bde0`](https://github.com/innocenzi/laravel-vite/commit/a16bde0)
- **vite**: print console diagnostics [`c78c1d5`](https://github.com/innocenzi/laravel-vite/commit/c78c1d5)
- **vite**: export options type [`75a6b97`](https://github.com/innocenzi/laravel-vite/commit/75a6b97)
- **vite**: adapt console output to Vite 3's [`52d61a2`](https://github.com/innocenzi/laravel-vite/commit/52d61a2)
- **vite**: add `importPageComponent` helper [`437e93f`](https://github.com/innocenzi/laravel-vite/commit/437e93f)
- **vite**: export `inertia` helpers [`964c557`](https://github.com/innocenzi/laravel-vite/commit/964c557)

### 🐞 Bug Fixes

- require `facade/ignition-contracts` [`#258`](https://github.com/innocenzi/laravel-vite/issues/258)
- update build dependencies [`b5902b9`](https://github.com/innocenzi/laravel-vite/commit/b5902b9)
- **plugin**: prevent artisan mocking in userland [`ff51605`](https://github.com/innocenzi/laravel-vite/commit/ff51605)
- **vite**: respect reload watch options [`980ba55`](https://github.com/innocenzi/laravel-vite/commit/980ba55)
- **vite**: update manifest plugin name [`af10a47`](https://github.com/innocenzi/laravel-vite/commit/af10a47)
- **vite**: prevent crashes by catching reload handler errors [`ff18d7d`](https://github.com/innocenzi/laravel-vite/commit/ff18d7d)
- **vite**: use app URL to infer certificate domain [`2ed157a`](https://github.com/innocenzi/laravel-vite/commit/2ed157a)
- **vite**: update typings [`0233d62`](https://github.com/innocenzi/laravel-vite/commit/0233d62)
- **vite**: invert dev server conditional [`32c5dd1`](https://github.com/innocenzi/laravel-vite/commit/32c5dd1)
- **vite**: bundle chalk to avoid `ERR_REQUIRE_ESM` [`601480c`](https://github.com/innocenzi/laravel-vite/commit/601480c)
- **vite**: downgrade `chalk` and externalize it [`6e9e53f`](https://github.com/innocenzi/laravel-vite/commit/6e9e53f)
- **vite**: move execa and chalk to deps [`18fe4d5`](https://github.com/innocenzi/laravel-vite/commit/18fe4d5)

##### [View changes on GitHub](https://github.com/innocenzi/laravel-vite/compare/v0.2.0-beta.5...v0.2.0-beta.21)
```

**With none of the new options**
```
➜  node /Users/enzoinnocenzi/Code/forks/changelogithub/cli.mjs --dry --from v0.2.0-beta.5                                 

changelogithub v0.5.0
innocenzi/laravel-vite
v0.2.0-beta.5 -> v0.2.0-beta.21 (92 commits)
--------------

### 🚨 Breaking Changes

- Add CSS and modulepreload tags for imported chunks [`#273`](https://github.com/innocenzi/laravel-vite/issues/273)

### 🚀 Features

- Throw when getting a tag for a non-existing entrypoint [`8db9189`](https://github.com/innocenzi/laravel-vite/commit/8db9189)
- Support multiple css file extensions in development [`#213`](https://github.com/innocenzi/laravel-vite/issues/213)
- Do not update tsconfig in production by default [`281bc87`](https://github.com/innocenzi/laravel-vite/commit/281bc87)
- Add `getEntryUrl` and `vite_entry_url` [`8f3ef9b`](https://github.com/innocenzi/laravel-vite/commit/8f3ef9b)
- Make `Vite` and `Configuration` macroable [`35efb23`](https://github.com/innocenzi/laravel-vite/commit/35efb23)
- Add `canAccessAssets` method [`b94dcb4`](https://github.com/innocenzi/laravel-vite/commit/b94dcb4)
- Support @vite/plugin-legacy [`#259`](https://github.com/innocenzi/laravel-vite/issues/259)
- Update default port to  `5173` [`b349c99`](https://github.com/innocenzi/laravel-vite/commit/b349c99)
- Move from `tsup` to `unbuild` [`0d55aaa`](https://github.com/innocenzi/laravel-vite/commit/0d55aaa)
- **chunk**:
  - Expose asset url [`e772739`](https://github.com/innocenzi/laravel-vite/commit/e772739)
- **vite**:
  - Log config info when Vite starts [`d2e15d5`](https://github.com/innocenzi/laravel-vite/commit/d2e15d5)
  - Add `watch` options [`a16bde0`](https://github.com/innocenzi/laravel-vite/commit/a16bde0)
  - Print console diagnostics [`c78c1d5`](https://github.com/innocenzi/laravel-vite/commit/c78c1d5)
  - Export options type [`75a6b97`](https://github.com/innocenzi/laravel-vite/commit/75a6b97)
  - Adapt console output to Vite 3's [`52d61a2`](https://github.com/innocenzi/laravel-vite/commit/52d61a2)
  - Add `importPageComponent` helper [`437e93f`](https://github.com/innocenzi/laravel-vite/commit/437e93f)
  - Export `inertia` helpers [`964c557`](https://github.com/innocenzi/laravel-vite/commit/964c557)

### 🐞 Bug Fixes

- Require `facade/ignition-contracts` [`#258`](https://github.com/innocenzi/laravel-vite/issues/258)
- Update build dependencies [`b5902b9`](https://github.com/innocenzi/laravel-vite/commit/b5902b9)
- **plugin**:
  - Prevent artisan mocking in userland [`ff51605`](https://github.com/innocenzi/laravel-vite/commit/ff51605)
- **vite**:
  - Respect reload watch options [`980ba55`](https://github.com/innocenzi/laravel-vite/commit/980ba55)
  - Update manifest plugin name [`af10a47`](https://github.com/innocenzi/laravel-vite/commit/af10a47)
  - Prevent crashes by catching reload handler errors [`ff18d7d`](https://github.com/innocenzi/laravel-vite/commit/ff18d7d)
  - Use app URL to infer certificate domain [`2ed157a`](https://github.com/innocenzi/laravel-vite/commit/2ed157a)
  - Update typings [`0233d62`](https://github.com/innocenzi/laravel-vite/commit/0233d62)
  - Invert dev server conditional [`32c5dd1`](https://github.com/innocenzi/laravel-vite/commit/32c5dd1)
  - Bundle chalk to avoid `ERR_REQUIRE_ESM` [`601480c`](https://github.com/innocenzi/laravel-vite/commit/601480c)
  - Downgrade `chalk` and externalize it [`6e9e53f`](https://github.com/innocenzi/laravel-vite/commit/6e9e53f)
  - Move execa and chalk to deps [`18fe4d5`](https://github.com/innocenzi/laravel-vite/commit/18fe4d5)

##### [View changes on GitHub](https://github.com/innocenzi/laravel-vite/compare/v0.2.0-beta.5...v0.2.0-beta.21)
```

</details>