### PR TITLE
chore: rm `contributors` from `args`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,6 @@ const args = minimist(process.argv.slice(2), {
   boolean: [
     'draft',
     'dry',
-    'contributors',
   ],
   string: [
     'token',


### PR DESCRIPTION
thinking this would be nice since having it as part of the `argv` parse with `minimist` prevents any overriding through a config file

unless the only intended way of setting that prop is through the `npx` call 🤔 