### PR TITLE
fix: fix a bug of wrong tag order due to missing taggerdate for lightweight tags

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -15,7 +15,7 @@ export async function isRepoShallow() {
 }
 
 export async function getLastGitTag(delta = 0) {
-  const tags = await execCommand('git', ['--no-pager', 'tag', '-l', '--sort=taggerdate']).then(r => r.split('\n'))
+  const tags = await execCommand('git', ['--no-pager', 'tag', '-l', '--sort=creatordate']).then(r => r.split('\n'))
   return tags[tags.length + delta - 1]
 }
 


### PR DESCRIPTION
For lightweight tags, the taggerdate attribute is empty:

```bash
git for-each-ref --sort=creatordate --format '%(refname) %(taggerdate)' refs/tags
refs/tags/0.1.0 Mon May 16 16:37:26 2022 +0800
refs/tags/0.2.0 Tue May 24 13:18:50 2022 +0800
refs/tags/0.3.0 Fri May 27 13:45:05 2022 +0800
refs/tags/0.3.1 Fri May 27 16:08:04 2022 +0800
refs/tags/0.4.0
refs/tags/0.4.1
```

Sorting by taggerdate will lead to wrong order. Fix it by changing to `creatordate`.