### PR TITLE
feat: support `--no-emoji`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ cli
   .option('--prerelease', 'Mark release as prerelease')
   .option('-d, --draft', 'Mark release as draft')
   .option('--capitalize', 'Should capitalize for each comment message')
+  .option('--emojis', 'Do not use emojis in section titles', { default: true })
   .option('--dry', 'Dry run')
   .help()
 
@@ -72,4 +73,3 @@ cli
   })
 
 cli.parse()
-

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ cli
   .option('--prerelease', 'Mark release as prerelease')
   .option('-d, --draft', 'Mark release as draft')
   .option('--capitalize', 'Should capitalize for each comment message')
-  .option('--emojis', 'Do not use emojis in section titles', { default: true })
+  .option('--emoji', 'Use emojis in section titles', { default: true })
   .option('--dry', 'Dry run')
   .help()
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,6 +1,8 @@
 import { partition } from '@antfu/utils'
 import type { Commit, ResolvedChangelogOptions } from './types'
 
+const emojisRE = /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
+
 function formatReferences(references: string[], github: string, type: 'pr' | 'hash'): string {
   const refs = references
     .filter((ref) => {
@@ -41,8 +43,8 @@ function formatLine(commit: Commit, options: ResolvedChangelogOptions) {
 }
 
 function formatTitle(name: string, options: ResolvedChangelogOptions) {
-  if (!options.emojis)
-    name = name.replace(/([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '')
+  if (!options.emoji)
+    name = name.replace(emojisRE, '')
 
   return `### &nbsp;&nbsp;&nbsp;${name.trim()}`
 }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -40,8 +40,11 @@ function formatLine(commit: Commit, options: ResolvedChangelogOptions) {
   return [description, authors, prRefs, hashRefs].filter(i => i?.trim()).join(' ')
 }
 
-function formatTitle(name: string) {
-  return `### &nbsp;&nbsp;&nbsp;${name}`
+function formatTitle(name: string, options: ResolvedChangelogOptions) {
+  if (!options.emojis)
+    name = name.replace(/([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '')
+
+  return `### &nbsp;&nbsp;&nbsp;${name.trim()}`
 }
 
 function formatSection(commits: Commit[], sectionName: string, options: ResolvedChangelogOptions) {
@@ -50,7 +53,7 @@ function formatSection(commits: Commit[], sectionName: string, options: Resolved
 
   const lines: string[] = [
     '',
-    formatTitle(sectionName),
+    formatTitle(sectionName, options),
     '',
   ]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
    * Use emojis in section titles
    * @default true
    */
-  emojis?: boolean
+  emoji?: boolean
 }
 
 export type ResolvedChangelogOptions = Required<ChangelogOptions>

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,11 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
    * @default true
    */
   groupByScope?: boolean
+  /**
+   * Use emojis in section titles
+   * @default true
+   */
+  emojis?: boolean
 }
 
 export type ResolvedChangelogOptions = Required<ChangelogOptions>


### PR DESCRIPTION
This PR supports a shortcut for removing emojis from section titles. By default, section titles are kept as-is, but if the `--no-emojis` flag is given to the CLI, emojis are stripped from the generated changelog.

I know I could use a custom configuration file, but as I want to use `changelogithub` in every project in place of `conventional-github-releaser`, I thought it would be nice to have a shortcut instead of copying a configuration file over and over.

This option feels a bit out of place though, so I understand if you'd rather not have it. In that case, how do you feel about a `--preset` option that would use a specific default configuration?

Sorry for the PR spam, this is the last one for me to be able to use your project ❤️ 