### PR TITLE
fix(cli): add missing `--group` option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ cli
   .option('-d, --draft', 'Mark release as draft')
   .option('--capitalize', 'Should capitalize for each comment message')
   .option('--emoji', 'Use emojis in section titles', { default: true })
+  .option('--group', 'Nest commit messages under their scopes')
   .option('--dry', 'Dry run')
   .help()
 


### PR DESCRIPTION
While trying all of the new options, I realized the config system changed. Previously I could do `--no-groupByScope` but I can't anymore, so I added the missing one for disabling grouping.

Now I can do `changelogithub --no-emoji --no-group --no-capitalize` :)

EDIT: sorry I PR'd that just before your release lol