### PR TITLE
fix(cli)!: rename `groupByScope` to `group`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ const defaultConfig: ChangelogOptions = {
   },
   contributors: true,
   capitalize: true,
-  groupByScope: true,
+  group: true,
 }
 
 export async function resolveConfig(options: ChangelogOptions) {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -64,7 +64,7 @@ function formatSection(commits: Commit[], sectionName: string, options: Resolved
     let padding = ''
     let prefix = ''
     const scopeText = `**${options.scopeMap[scope] || scope}**`
-    if (scope && options.groupByScope) {
+    if (scope && options.group) {
       lines.push(`- ${scopeText}:`)
       padding = '  '
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
    * Nest commit messages under their scopes
    * @default true
    */
-  groupByScope?: boolean
+  group?: boolean
   /**
    * Use emojis in section titles
    * @default true


### PR DESCRIPTION
Hey, because I'm an idiot I forgot to `stash pop` the rename commit I made after I tested my changes in https://github.com/antfu/changelogithub/pull/21. So that PR is actually useless without merging this one, I'm sorry :(