### PR TITLE
fix: remove brackets for references

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -10,7 +10,7 @@ export function parseCommits(commits: RawGitCommit[], config: ChangelogenOptions
 // https://regex101.com/r/FSfNvA/1
 const ConventionalCommitRegex = /(?<type>[a-z]+)(\((?<scope>.+)\))?(?<breaking>!)?: (?<description>.+)/i
 const CoAuthoredByRegex = /Co-authored-by:\s*(?<name>.+)(<(?<email>.+)>)/gmi
-const ReferencesRegex = /\(#[0-9]+\)/gm
+const ReferencesRegex = /\((#[0-9]+)\)/gm
 
 export function parseGitCommit(commit: RawGitCommit, config: ChangelogenOptions): GitCommit | null {
   const match = commit.message.match(ConventionalCommitRegex)
@@ -31,9 +31,8 @@ export function parseGitCommit(commit: RawGitCommit, config: ChangelogenOptions)
 
   const matches = description.matchAll(ReferencesRegex)
   for (const m of matches) {
-    const reference = m[0]
     // Remove brackets for references
-    references.push(reference.slice(1, reference.length - 1))
+    references.push(m[1])
   }
 
   if (!references.length)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -31,7 +31,7 @@ export function parseGitCommit(commit: RawGitCommit, config: ChangelogenOptions)
 
   const matches = description.matchAll(ReferencesRegex)
   for (const m of matches) {
-    const reference = m[0];
+    const reference = m[0]
     // Remove brackets for references
     references.push(reference.slice(1, reference.length - 1))
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -30,8 +30,11 @@ export function parseGitCommit(commit: RawGitCommit, config: ChangelogenOptions)
   const references = []
 
   const matches = description.matchAll(ReferencesRegex)
-  for (const m of matches)
-    references.push(m[0])
+  for (const m of matches) {
+    const reference = m[0];
+    // Remove brackets for references
+    references.push(reference.slice(1, reference.length - 1))
+  }
 
   if (!references.length)
     references.push(commit.shortHash)


### PR DESCRIPTION
https://github.com/antfu/changelogithub/blob/efdec419b22156cb1218a73f10057181c3baa2dc/src/markdown.ts#L7-L12

After 5cc6950d953a8448849fee16162743cb0e1f380c, references are considered as hashes because of the extra brackets

Take this commit message as an example:
```
fix: missing brackets (#11)
```

Before:
![2022-07-05_15-53](https://user-images.githubusercontent.com/35414841/177278766-d21b7097-2127-4a45-9bdc-64e39336d95c.png)

After:
![2022-07-05_15-54](https://user-images.githubusercontent.com/35414841/177278803-4395884e-d308-4e84-aab4-5581805198c0.png)

