### PR TITLE
feat(chore): implemented gitmoji support

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "c12": "^0.2.8",
     "cac": "^6.7.12",
     "changelogen": "0.1.1",
+    "convert-gitmoji": "0.1.2",
     "execa": "^6.1.0",
     "kolorist": "^1.5.1",
     "ohmyfetch": "^0.4.18"

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,4 +1,5 @@
 import { partition } from '@antfu/utils'
+import { convert } from 'convert-gitmoji'
 import type { Commit, ResolvedChangelogOptions } from './types'
 
 const emojisRE = /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
@@ -114,7 +115,7 @@ export function generateMarkdown(commits: Commit[], options: ResolvedChangelogOp
 
   lines.push('', `##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](${url})`)
 
-  return lines.join('\n').trim()
+  return convert(lines.join('\n').trim(), true)
 }
 
 function groupBy<T>(items: T[], key: string, groups: Record<string, T[]> = {}) {


### PR DESCRIPTION
Implemented the gitmoji support using `convert-gitmoji`, same as here: https://github.com/unjs/changelogen/commit/4346f6113c49a4e695d2e30ac36f067561f0a436

As long as #4 isn't resolved, I figured it made sense to implement it here as well.