### PR TITLE
feat: presets

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,8 +17,9 @@ cli
   .option('--prerelease', 'Mark release as prerelease')
   .option('-d, --draft', 'Mark release as draft')
   .option('--capitalize', 'Should capitalize for each comment message')
-  .option('--emoji', 'Use emojis in section titles', { default: true })
+  .option('--emoji', 'Use emojis in section titles')
   .option('--group', 'Nest commit messages under their scopes')
+  .option('--preset <preset>', 'Use a formatting preset', { default: 'default' })
   .option('--dry', 'Dry run')
   .help()
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { getCurrentGitBranch, getFirstGitCommit, getGitHubRepo, getLastGitTag, isPrerelease } from './git'
+import { resolvePreset } from './presets'
 import type { ChangelogOptions, ResolvedChangelogOptions } from './types'
 
 export function defineConfig(config: ChangelogOptions) {
@@ -18,14 +19,19 @@ const defaultConfig: ChangelogOptions = {
   contributors: true,
   capitalize: true,
   group: true,
+  emoji: true,
 }
 
 export async function resolveConfig(options: ChangelogOptions) {
   const { loadConfig } = await import('c12')
+  const preset = resolvePreset(options.preset)
   const config = await loadConfig<ChangelogOptions>({
     name: 'changelogithub',
     defaults: defaultConfig,
-    overrides: options,
+    overrides: {
+      ...preset.options,
+      ...options,
+    },
   }).then(r => r.config || defaultConfig)
 
   config.from = config.from || await getLastGitTag()
@@ -36,5 +42,8 @@ export async function resolveConfig(options: ChangelogOptions) {
   if (config.to === config.from)
     config.from = await getLastGitTag(-1) || await getFirstGitCommit()
 
-  return config as ResolvedChangelogOptions
+  return {
+    ...config,
+    preset,
+  } as ResolvedChangelogOptions
 }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,64 +1,40 @@
 import { partition } from '@antfu/utils'
 import { convert } from 'convert-gitmoji'
+import { capitalize, emojisRE, groupBy } from './utils'
 import type { Commit, ResolvedChangelogOptions } from './types'
 
-const emojisRE = /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
-
-function formatReferences(references: string[], github: string, type: 'pr' | 'hash'): string {
+function formatReferences(options: ResolvedChangelogOptions, references: string[], type: 'pr' | 'hash'): string {
   const refs = references
     .filter((ref) => {
       if (type === 'pr')
         return ref[0] === '#'
       return ref[0] !== '#'
     })
-    .map((ref) => {
-      if (!github)
-        return ref
+    .map(ref => options.preset.formatSingleReference({ options, ref, type }))
 
-      if (type === 'pr')
-        return `https://github.com/${github}/issues/${ref.slice(1)}`
-      return `[<samp>(${ref.slice(0, 5)})</samp>](https://github.com/${github}/commit/${ref})`
-    })
-
-  const referencesString = join(refs).trim()
-
-  if (type === 'pr')
-    return referencesString && `in ${referencesString}`
-  return referencesString
+  return options.preset.formatReferences({ options, type, refs })
 }
 
 function formatLine(commit: Commit, options: ResolvedChangelogOptions) {
-  const prRefs = formatReferences(commit.references, options.github, 'pr')
-  const hashRefs = formatReferences(commit.references, options.github, 'hash')
-
-  let authors = join([...new Set(commit.resolvedAuthors?.map(i => i.login ? `@${i.login}` : `**${i.name}**`))])?.trim()
-  if (authors)
-    authors = `by ${authors}`
-
-  let refs = [authors, prRefs, hashRefs].filter(i => i?.trim()).join(' ')
-
-  if (refs)
-    refs = `&nbsp;-&nbsp; ${refs}`
-
+  const prRefs = formatReferences(options, commit.references, 'pr')
+  const hashRefs = formatReferences(options, commit.references, 'hash')
+  const authors = options.preset.formatAuthors({ options, authors: commit.resolvedAuthors })
+  const refs = options.preset.formatCommitSuffix({ options, authors, prRefs, hashRefs })
   const description = options.capitalize ? capitalize(commit.description) : commit.description
 
   return [description, refs].filter(i => i?.trim()).join(' ')
 }
 
-function formatTitle(name: string, options: ResolvedChangelogOptions) {
-  if (!options.emoji)
-    name = name.replace(emojisRE, '')
-
-  return `### &nbsp;&nbsp;&nbsp;${name.trim()}`
-}
-
-function formatSection(commits: Commit[], sectionName: string, options: ResolvedChangelogOptions) {
+function formatSection(commits: Commit[], title: string, options: ResolvedChangelogOptions) {
   if (!commits.length)
     return []
 
+  if (!options.emoji)
+    title = title.replace(emojisRE, '')
+
   const lines: string[] = [
     '',
-    formatTitle(sectionName, options),
+    options.preset.formatTitle({ title, options }),
     '',
   ]
 
@@ -97,49 +73,20 @@ export function generateMarkdown(commits: Commit[], options: ResolvedChangelogOp
 
   const group = groupBy(changes, 'type')
 
-  lines.push(
-    ...formatSection(breaking, options.titles.breakingChanges!, options),
-  )
+  lines.push(...formatSection(breaking, options.titles.breakingChanges!, options))
 
   for (const type of Object.keys(options.types)) {
     const items = group[type] || []
-    lines.push(
-      ...formatSection(items, options.types[type].title, options),
-    )
+    lines.push(...formatSection(items, options.types[type].title, options))
   }
 
   if (!lines.length)
-    lines.push('*No significant changes*')
+    lines.push(options.preset.formatEmptyChangelog({ options }))
 
-  const url = `https://github.com/${options.github}/compare/${options.from}...${options.to}`
-
-  lines.push('', `##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](${url})`)
+  lines.push('', options.preset.formatDiff({
+    options,
+    url: `https://github.com/${options.github}/compare/${options.from}...${options.to}`,
+  }))
 
   return convert(lines.join('\n').trim(), true)
-}
-
-function groupBy<T>(items: T[], key: string, groups: Record<string, T[]> = {}) {
-  for (const item of items) {
-    const v = (item as any)[key] as string
-    groups[v] = groups[v] || []
-    groups[v].push(item)
-  }
-  return groups
-}
-
-function capitalize(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1)
-}
-
-function join(array?: string[], glue = ', ', finalGlue = ' and '): string {
-  if (!array || array.length === 0)
-    return ''
-
-  if (array.length === 1)
-    return array[0]
-
-  if (array.length === 2)
-    return array.join(finalGlue)
-
-  return `${array.slice(0, -1).join(glue)}${finalGlue}${array.slice(-1)}`
 }

--- a/src/presets/default.ts
+++ b/src/presets/default.ts
@@ -1,0 +1,43 @@
+import { join } from '../utils'
+import { definePreset } from './index'
+
+export default definePreset({
+  name: 'default',
+  formatSingleReference: ({ ref, type, options }) => {
+    if (!options.github)
+      return ref
+
+    if (type === 'pr')
+      return `https://github.com/${options.github}/issues/${ref.slice(1)}`
+
+    return `[<samp>(${ref.slice(0, 5)})</samp>](https://github.com/${options.github}/commit/${ref})`
+  },
+  formatReferences: ({ refs, type }) => {
+    const referencesString = join(refs).trim()
+
+    if (type === 'pr')
+      return referencesString && `in ${referencesString}`
+    return referencesString
+  },
+  formatAuthors: ({ authors }) => {
+    const str = join([...new Set(authors?.map(i => i.login ? `@${i.login}` : `**${i.name}**`))])?.trim()
+    return str
+      ? `by ${str}`
+      : ''
+  },
+  formatCommitSuffix: ({ authors, prRefs, hashRefs }) => {
+    const refs = [authors, prRefs, hashRefs].filter(i => i?.trim()).join(' ')
+    return refs
+      ? `&nbsp;-&nbsp; ${refs}`
+      : ''
+  },
+  formatTitle: ({ title }) => {
+    return `### &nbsp;&nbsp;&nbsp;${title.trim()}`
+  },
+  formatEmptyChangelog: () => {
+    return '*No significant changes*'
+  },
+  formatDiff: ({ url }) => {
+    return `##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](${url})`
+  },
+})

--- a/src/presets/github.ts
+++ b/src/presets/github.ts
@@ -1,0 +1,31 @@
+import defaultPreset from './default'
+import { definePreset } from './index'
+
+export default definePreset({
+  ...defaultPreset,
+  name: 'github',
+  options: {
+    emoji: false,
+    contributors: true,
+    capitalize: false,
+    group: false,
+  },
+  formatSingleReference: ({ ref, type, options }) => {
+    if (!options.github)
+      return ref
+
+    if (type === 'pr')
+      return `https://github.com/${options.github}/issues/${ref.slice(1)}`
+
+    return `([${ref.slice(0, 6)}](https://github.com/${options.github}/commit/${ref}))`
+  },
+  formatCommitSuffix: ({ authors, prRefs, hashRefs }) => {
+    return [authors, prRefs, hashRefs].filter(i => i?.trim()).join(' ')
+  },
+  formatTitle: ({ title }) => {
+    return `### ${title.trim()}`
+  },
+  formatDiff: ({ url }) => {
+    return `#### **Full changelog**: ${url}`
+  },
+})

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,0 +1,57 @@
+import type { AuthorInfo, ChangelogOptions } from '../types'
+import githubPreset from './github'
+import defaultPreset from './default'
+
+interface FormatArguments {
+  options: Omit<ChangelogOptions, 'preset'>
+}
+
+interface FormatSingleRefArguments extends FormatArguments {
+  ref: string
+  type: 'pr' | 'hash'
+}
+
+interface FormatRefsArguments extends FormatArguments {
+  refs: string[]
+  type: 'pr' | 'hash'
+}
+
+interface FormatAuthorsArguments extends FormatArguments {
+  authors?: AuthorInfo[]
+}
+
+interface FormatCommitSuffixArguments extends FormatArguments {
+  authors: string
+  prRefs: string
+  hashRefs: string
+}
+
+interface FormatTitleArguments extends FormatArguments {
+  title: string
+}
+
+interface FormatDiffArguments extends FormatArguments {
+  url: string
+}
+
+export interface Preset {
+  name: string
+  options?: Omit<ChangelogOptions, 'preset'>
+  formatSingleReference: (args: FormatSingleRefArguments) => string
+  formatReferences: (args: FormatRefsArguments) => string
+  formatAuthors: (args: FormatAuthorsArguments) => string
+  formatCommitSuffix: (args: FormatCommitSuffixArguments) => string
+  formatTitle: (args: FormatTitleArguments) => string
+  formatDiff: (args: FormatDiffArguments) => string
+  formatEmptyChangelog: (args: FormatArguments) => string
+}
+
+export function definePreset(preset: Preset): Preset {
+  return preset
+}
+
+export function resolvePreset(name?: string): Preset {
+  return [
+    githubPreset,
+  ].find(preset => preset.name === name) ?? defaultPreset
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { GitCommit } from 'changelogen'
+import type { Preset } from './presets'
 
 export interface GitHubRepo {
   owner: string
@@ -70,9 +71,16 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
    * @default true
    */
   emoji?: boolean
+  /**
+   * Use a formatting preset
+   * @default default
+   */
+  preset?: 'github' | 'default'
 }
 
-export type ResolvedChangelogOptions = Required<ChangelogOptions>
+export type ResolvedChangelogOptions = Required<ChangelogOptions> & {
+  preset: Preset
+}
 
 export interface AuthorInfo {
   commits: string[]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,27 @@
+export const emojisRE = /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
+
+export function groupBy<T>(items: T[], key: string, groups: Record<string, T[]> = {}) {
+  for (const item of items) {
+    const v = (item as any)[key] as string
+    groups[v] = groups[v] || []
+    groups[v].push(item)
+  }
+  return groups
+}
+
+export function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+export function join(array?: string[], glue = ', ', finalGlue = ' and '): string {
+  if (!array || array.length === 0)
+    return ''
+
+  if (array.length === 1)
+    return array[0]
+
+  if (array.length === 2)
+    return array.join(finalGlue)
+
+  return `${array.slice(0, -1).join(glue)}${finalGlue}${array.slice(-1)}`
+}


### PR DESCRIPTION
So... I like this project a lot, and I am a perfectionist/opinionated person.

I previously PR'd a few new formatting options for the changelog to look closely to what I was used to, but the project is active and moving forward so the changelogs formatting is not the same between each release. 

In my PR to add the `--emoji` flag, I suggested a preset feature because that option was a bit out of place. I ended up hacking on that feature anyway in order to have a set of stable presets.

Currently, there is a `default` and a `github` preset. 
- The `default` one is the current one, it has the looks of the currently generated changelogs at the moment of the PR.
- The `github` one is a preset that formats more closely to what the GitHub-generated changelog looks like:
	- It uses no emoji (like `--no-emoji`)
	- It doesn't group commits (like `--no-group`)
	- It doesn't capitalize commit messages (like `--no-capitalize`)
	- It formats the "full changelog" link like GitHub's
	- It formats commit messages' suffixes like GitHub does (6 chars hashes, no `-` separator, no monospace)

A preset is defined using the `--preset <preset>` flag or by using the `preset` option of a `changelogithub` configuration file. If an incorrect preset name is given, the default one will be used.

Additionally, command-line parameters take precedence over any option configured by the preset. For instance, `changelogithub --preset github --capitalize` will indeed capitalize commit messages.

This PR should not introduce any breaking change.