### PR TITLE
fix: change `isPrerelease()` to be more generic

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -34,7 +34,7 @@ export async function getFirstGitCommit() {
 }
 
 export function isPrerelease(version: string) {
-  return !/^[\d.]+$/.test(version)
+  return !/^[^.]*[\d.]+$/.test(version)
 }
 
 async function execCommand(cmd: string, args: string[]) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -34,7 +34,7 @@ export async function getFirstGitCommit() {
 }
 
 export function isPrerelease(version: string) {
-  return version.includes('-')
+  return !/^[\d.]+$/.test(version)
 }
 
 async function execCommand(cmd: string, args: string[]) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In Python, the prerelease version `1.0.0-alpha.1` will be normalized to `1.0.0a1`, so change the `isPrerelease` function to be more generic.

The regex will consider the following as prerelease:

- `v1.0.0a0`
- `1.0.0a0`
- `v1.0.0-beta.1`

While the following are non-prereleases:

- `v1.2.0`
- `1.0.0`
- `version-6.0.0`
- `r6`

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
