### PR TITLE
feat: option to only group scope with multiple commits

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -63,12 +63,17 @@ function formatSection(commits: Commit[], sectionName: string, options: Resolved
   ]
 
   const scopes = groupBy(commits, 'scope')
+  let useScopeGroup = options.group
+
+  // group scopes only when one of the scope have multiple commits
+  if (!Object.entries(scopes).some(([k, v]) => k && v.length > 1))
+    useScopeGroup = false
 
   Object.keys(scopes).sort().forEach((scope) => {
     let padding = ''
     let prefix = ''
     const scopeText = `**${options.scopeMap[scope] || scope}**`
-    if (scope && options.group && scopes[scope].length > 1) {
+    if (scope && (useScopeGroup === true || (useScopeGroup === 'multiple' && scopes[scope].length > 1))) {
       lines.push(`- ${scopeText}:`)
       padding = '  '
     }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -63,17 +63,12 @@ function formatSection(commits: Commit[], sectionName: string, options: Resolved
   ]
 
   const scopes = groupBy(commits, 'scope')
-  let useScopeGroup = options.group
-
-  // group scopes only when one of the scope have multiple commits
-  if (!Object.entries(scopes).some(([k, v]) => k && v.length > 1))
-    useScopeGroup = false
 
   Object.keys(scopes).sort().forEach((scope) => {
     let padding = ''
     let prefix = ''
     const scopeText = `**${options.scopeMap[scope] || scope}**`
-    if (scope && useScopeGroup) {
+    if (scope && options.group && scopes[scope].length > 1) {
       lines.push(`- ${scopeText}:`)
       padding = '  '
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
    * Nest commit messages under their scopes
    * @default true
    */
-  group?: boolean
+  group?: boolean | 'multiple'
   /**
    * Use emojis in section titles
    * @default true

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -47,7 +47,8 @@ test('parse', async () => {
     - Throw on shallow repo - by **Anthony Fu** [<samp>(f1c1f)</samp>](https://github.com/antfu/changelogithub/commit/f1c1fad)
     - Improve how references are displayed - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/19 [<samp>(cdf8f)</samp>](https://github.com/antfu/changelogithub/commit/cdf8fe5)
     - Support \`--no-emoji\` - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/20 [<samp>(e94ba)</samp>](https://github.com/antfu/changelogithub/commit/e94ba4a)
-    - **contributors**: Improve author list - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/18 [<samp>(8d8d9)</samp>](https://github.com/antfu/changelogithub/commit/8d8d914)
+    - **contributors**:
+     - Improve author list - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/18 [<samp>(8d8d9)</samp>](https://github.com/antfu/changelogithub/commit/8d8d914)
     - **style**:
      - Group scopes only when one of the scope have multiple commits - by **Anthony Fu** [<samp>(312f7)</samp>](https://github.com/antfu/changelogithub/commit/312f796)
      - Use \`<sup>\` for author info - by **Anthony Fu** [<samp>(b51c0)</samp>](https://github.com/antfu/changelogithub/commit/b51c075)

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -47,8 +47,7 @@ test('parse', async () => {
     - Throw on shallow repo - by **Anthony Fu** [<samp>(f1c1f)</samp>](https://github.com/antfu/changelogithub/commit/f1c1fad)
     - Improve how references are displayed - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/19 [<samp>(cdf8f)</samp>](https://github.com/antfu/changelogithub/commit/cdf8fe5)
     - Support \`--no-emoji\` - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/20 [<samp>(e94ba)</samp>](https://github.com/antfu/changelogithub/commit/e94ba4a)
-    - **contributors**:
-     - Improve author list - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/18 [<samp>(8d8d9)</samp>](https://github.com/antfu/changelogithub/commit/8d8d914)
+    - **contributors**: Improve author list - by **Enzo Innocenzi** in https://github.com/antfu/changelogithub/issues/18 [<samp>(8d8d9)</samp>](https://github.com/antfu/changelogithub/commit/8d8d914)
     - **style**:
      - Group scopes only when one of the scope have multiple commits - by **Anthony Fu** [<samp>(312f7)</samp>](https://github.com/antfu/changelogithub/commit/312f796)
      - Use \`<sup>\` for author info - by **Anthony Fu** [<samp>(b51c0)</samp>](https://github.com/antfu/changelogithub/commit/b51c075)


### PR DESCRIPTION
### Description

The group scope feature is very useful, but when there is only one scope that have multiple commits, it could lead to output like this:

> - **Feature1**:
>   - Lorem ipsum dolor sit amet consectetur adipisicing elit...
> - **Feature2**:
>   - Ipsum ea eligendi deleniti blanditiis...
> - **Feature3**:
>   - Numquam, blanditiis placeat esse accusantium iusto...
> - **Feature4**:
>   - vel quae possimus nobis voluptatem...
>   - ipsa fugiat error, molestias aliquam? Molestias...

In some cases you only want to group the scope when it have multiple commits, so you could get output like this:

> - **Feature1**: Lorem ipsum dolor sit amet consectetur adipisicing elit...
> - **Feature2**: Ipsum ea eligendi deleniti blanditiis...
> - **Feature3**: Numquam, blanditiis placeat esse accusantium iusto...
> - **Feature4**:
>   - vel quae possimus nobis voluptatem...
>   - ipsa fugiat error, molestias aliquam? Molestias...

So I've added an option `multiple` to the `group` config that only group scope when it have multiple commits