### PR TITLE
fix(config): fix package-json configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ export async function resolveConfig(options: ChangelogOptions) {
     name: 'changelogithub',
     defaults: defaultConfig,
     overrides: options,
+    packageJson: true,
   }).then(r => r.config || defaultConfig)
 
   config.to = config.to || await getCurrentGitBranch()


### PR DESCRIPTION
Noticed that if I want to config this package inside my root package.json nothing worked, so look through official [unjs/c12](https://github.com/unjs/c12) docs and noticed that if we want to import from package.json need to set option to `true`, [link to anchor](https://github.com/unjs/c12?tab=readme-ov-file#packagejson):

<img width="900" alt="image" src="https://github.com/antfu/changelogithub/assets/82209198/4f91cdb0-f341-4858-8d98-ad5ab6cd31ae">

Don't know how to test it, but think this will fixed it ❤️ 

```typescript
const config = await loadConfig<ChangelogOptions>({
    name: 'changelogithub',
    defaults: defaultConfig,
    overrides: options,
    // added this 👇  
    packageJson: true,
  }).then(r => r.config || defaultConfig)
``` 