### PR TITLE
fix(config): change packageJson key from 'true' to predefined name

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export async function resolveConfig(options: ChangelogOptions) {
     name: 'changelogithub',
     defaults: defaultConfig,
     overrides: options,
-    packageJson: true,
+    packageJson: 'changelogithub',
   }).then(r => r.config || defaultConfig)
 
   config.to = config.to || await getCurrentGitBranch()


### PR DESCRIPTION
Ref: [#41](https://github.com/antfu/changelogithub/pull/41)

Sorry, but this don't worked for me, I don't know why, but maybe we need to predefine name for `packageJson` key, I make one more PR, but need to test it, locally in this project everything works fine 🙂

❤️