### PR TITLE
feat: add support for Github Enterprise, fix #45

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ cli
       console.log(dim(`changelo${bold('github')} `) + dim(`v${version}`))
 
       const { config, md, commits } = await generate(args as any)
-      webUrl = `https://github.com/${config.repo}/releases/new?title=${encodeURIComponent(String(config.name || config.to))}&body=${encodeURIComponent(String(md))}&tag=${encodeURIComponent(String(config.to))}&prerelease=${config.prerelease}`
+      webUrl = `https://${config.baseUrl}/${config.repo}/releases/new?title=${encodeURIComponent(String(config.name || config.to))}&body=${encodeURIComponent(String(md))}&tag=${encodeURIComponent(String(config.to))}&prerelease=${config.prerelease}`
 
       console.log(cyan(config.from) + dim(' -> ') + blue(config.to) + dim(` (${commits.length} commits)`))
       console.log(dim('--------------'))

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,8 @@ export async function resolveConfig(options: ChangelogOptions) {
     packageJson: 'changelogithub',
   }).then(r => r.config || defaultConfig)
 
+  config.baseUrl = config.baseUrl ?? 'github.com'
+  config.baseUrlApi = config.baseUrlApi ?? 'api.github.com'
   config.to = config.to || await getCurrentGitBranch()
   config.from = config.from || await getLastMatchingTag(config.to) || await getFirstGitCommit()
   // @ts-expect-error backward compatibility

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export async function resolveConfig(options: ChangelogOptions) {
   config.to = config.to || await getCurrentGitBranch()
   config.from = config.from || await getLastMatchingTag(config.to) || await getFirstGitCommit()
   // @ts-expect-error backward compatibility
-  config.repo = config.repo || config.github || await getGitHubRepo()
+  config.repo = config.repo || config.github || await getGitHubRepo(config.baseUrl)
   config.prerelease = config.prerelease ?? isPrerelease(config.to)
 
   if (typeof config.repo !== 'string')

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,8 @@
-export async function getGitHubRepo() {
+export async function getGitHubRepo(baseUrl: string) {
   const url = await execCommand('git', ['config', '--get', 'remote.origin.url'])
-  const match = url.match(/github\.com[\/:]([\w\d._-]+?)\/([\w\d._-]+?)(\.git)?$/i)
+  const escapedBaseUrl = baseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regex = new RegExp(`${escapedBaseUrl}[\/:]([\\w\\d._-]+?)\\/([\\w\\d._-]+?)(\\.git)?$`, 'i')
+  const match = regex.exec(url)
   if (!match)
     throw new Error(`Can not parse GitHub repo from url ${url}`)
   return `${match[1]}/${match[2]}`

--- a/src/github.ts
+++ b/src/github.ts
@@ -9,11 +9,11 @@ export async function sendRelease(
   content: string,
 ) {
   const headers = getHeaders(options)
-  let url = `https://api.github.com/repos/${options.repo}/releases`
+  let url = `https://${options.baseUrlApi}/repos/${options.repo}/releases`
   let method = 'POST'
 
   try {
-    const exists = await $fetch(`https://api.github.com/repos/${options.repo}/releases/tags/${options.to}`, {
+    const exists = await $fetch(`https://${options.baseUrlApi}/repos/${options.repo}/releases/tags/${options.to}`, {
       headers,
     })
     if (exists.url) {
@@ -59,7 +59,7 @@ export async function resolveAuthorInfo(options: ChangelogOptions, info: AuthorI
     return info
 
   try {
-    const data = await $fetch(`https://api.github.com/search/users?q=${encodeURIComponent(info.email)}`, {
+    const data = await $fetch(`https://${options.baseUrlApi}/search/users?q=${encodeURIComponent(info.email)}`, {
       headers: getHeaders(options),
     })
     info.login = data.items[0].login
@@ -71,7 +71,7 @@ export async function resolveAuthorInfo(options: ChangelogOptions, info: AuthorI
 
   if (info.commits.length) {
     try {
-      const data = await $fetch(`https://api.github.com/repos/${options.repo}/commits/${info.commits[0]}`, {
+      const data = await $fetch(`https://${options.baseUrlApi}/repos/${options.repo}/commits/${info.commits[0]}`, {
         headers: getHeaders(options),
       })
       info.login = data.author.login
@@ -128,7 +128,7 @@ export async function resolveAuthors(commits: Commit[], options: ChangelogOption
 
 export async function hasTagOnGitHub(tag: string, options: ChangelogOptions) {
   try {
-    await $fetch(`https://api.github.com/repos/${options.repo}/git/ref/tags/${tag}`, {
+    await $fetch(`https://${options.baseUrlApi}/repos/${options.repo}/git/ref/tags/${tag}`, {
       headers: getHeaders(options),
     })
     return true

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -5,7 +5,7 @@ import type { Commit, ResolvedChangelogOptions } from './types'
 
 const emojisRE = /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
 
-function formatReferences(references: Reference[], github: string, type: 'issues' | 'hash'): string {
+function formatReferences(references: Reference[], baseUrl: string, github: string, type: 'issues' | 'hash'): string {
   const refs = references
     .filter((i) => {
       if (type === 'issues')
@@ -16,8 +16,8 @@ function formatReferences(references: Reference[], github: string, type: 'issues
       if (!github)
         return ref.value
       if (ref.type === 'pull-request' || ref.type === 'issue')
-        return `https://github.com/${github}/issues/${ref.value.slice(1)}`
-      return `[<samp>(${ref.value.slice(0, 5)})</samp>](https://github.com/${github}/commit/${ref.value})`
+        return `https://${baseUrl}/${github}/issues/${ref.value.slice(1)}`
+      return `[<samp>(${ref.value.slice(0, 5)})</samp>](https://${baseUrl}/${github}/commit/${ref.value})`
     })
 
   const referencesString = join(refs).trim()
@@ -28,8 +28,8 @@ function formatReferences(references: Reference[], github: string, type: 'issues
 }
 
 function formatLine(commit: Commit, options: ResolvedChangelogOptions) {
-  const prRefs = formatReferences(commit.references, options.repo as string, 'issues')
-  const hashRefs = formatReferences(commit.references, options.repo as string, 'hash')
+  const prRefs = formatReferences(commit.references, options.baseUrl, options.repo as string, 'issues')
+  const hashRefs = formatReferences(commit.references, options.baseUrl, options.repo as string, 'hash')
 
   let authors = join([...new Set(commit.resolvedAuthors?.map(i => i.login ? `@${i.login}` : `**${i.name}**`))])?.trim()
   if (authors)
@@ -111,7 +111,7 @@ export function generateMarkdown(commits: Commit[], options: ResolvedChangelogOp
   if (!lines.length)
     lines.push('*No significant changes*')
 
-  const url = `https://github.com/${options.repo}/compare/${options.from}...${options.to}`
+  const url = `https://${options.baseUrl}/${options.repo}/compare/${options.from}...${options.to}`
 
   lines.push('', `##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](${url})`)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,16 @@ export interface ChangelogOptions extends Partial<ChangelogenOptions> {
    * @default true
    */
   emoji?: boolean
+  /**
+   * Github base url
+   * @default github.com
+   */
+  baseUrl?: string
+  /**
+   * Github base API url
+   * @default api.github.com
+   */
+  baseUrlApi?: string
 }
 
 export type ResolvedChangelogOptions = Required<ChangelogOptions>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Add support into `config` to retrieve custom Github url, allowing Github Enterprise to be used with this dependency.

This pull request was tested with two scenarios:

##### with repo

```
export default {
  baseUrl: "git.custom.com",
  baseUrlApi: "git.custom.com/api/v3",
  repo: "eliamartani/myrepo",
};
```

##### without repo

```
export default {
  baseUrl: "git.custom.com",
  baseUrlApi: "git.custom.com/api/v3",
};
```

Some other tests were added to cover some additions made with the Pull Request

### Linked Issues

Closes #45

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
