### PR TITLE
fix: find last stable release tag using semver

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -31,7 +31,7 @@ export async function getLastMatchingTag(inputTag: string) {
   let tag: string | undefined
   // Doing a stable release, find the last stable release to compare with
   if (!isPrerelease && isVersion)
-    tag = tags.find(tag => tag !== inputTag && tag[0] === 'v' && !tag.includes('-'))
+    tag = tags.find(tag => tag !== inputTag && semver.valid(semver.coerce(tag)) && semver.prerelease(tag) === null)
 
   // Fallback to the last tag, that are not the input tag
   tag ||= tags.find(tag => tag !== inputTag)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Sorry for this bug introduced in #47.

With this fix, it should be able to find the correct latest stable tag regardless of whether there is a v prefix.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
