### PR TITLE
chore: recommend Node LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - name: Set node
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          registry-url: https://registry.npmjs.org/
+          node-version: lts/*
 
       - run: npx changelogithub # or changelogithub@0.12 if ensure the stable result
         env:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The current README snippet configures Actions to use Node 16, causing the workflow to fail ([example here](https://github.com/baleada/vue-features/actions/runs/10544396633/job/29213517997#step:4:73)).

This edit recommends Node LTS instead, following the example of the changelogithub repo itself.


### Linked Issues


### Additional context
