### PR TITLE
fix: remove `&nbsp;` on github releases create url

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,12 +49,13 @@ cli
       console.log(dim(`changelo${bold('github')} `) + dim(`v${version}`))
 
       const { config, md, commits } = await generate(args as any)
-      webUrl = `https://${config.baseUrl}/${config.releaseRepo}/releases/new?title=${encodeURIComponent(String(config.name || config.to))}&body=${encodeURIComponent(String(md))}&tag=${encodeURIComponent(String(config.to))}&prerelease=${config.prerelease}`
+      const printMd = md.replace(/&nbsp;/g, '')
+      webUrl = `https://${config.baseUrl}/${config.releaseRepo}/releases/new?title=${encodeURIComponent(String(config.name || config.to))}&body=${encodeURIComponent(printMd)}&tag=${encodeURIComponent(String(config.to))}&prerelease=${config.prerelease}`
 
       console.log(cyan(config.from) + dim(' -> ') + blue(config.to) + dim(` (${commits.length} commits)`))
       console.log(dim('--------------'))
       console.log()
-      console.log(md.replace(/&nbsp;/g, ''))
+      console.log(printMd)
       console.log()
       console.log(dim('--------------'))
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The `&nbsp;` placeholder is redundant and needs to be removed

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Before
![image](https://github.com/user-attachments/assets/bed834ea-6808-495d-a031-3643c7cfe09a)

After
![image](https://github.com/user-attachments/assets/d8f7eea7-5891-4568-9aab-0a6fab947f21)
