### PR TITLE
fix: "token" does not take effect in the configuration file.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,8 +40,12 @@ async function readTokenFromGitHubCli() {
 cli
   .command('')
   .action(async (args) => {
-    args.token = args.token || process.env.GITHUB_TOKEN || await readTokenFromGitHubCli()
+    const token = args.token || process.env.GITHUB_TOKEN || await readTokenFromGitHubCli()
 
+    if (token) {
+      args.token = token
+    }
+    
     let webUrl = ''
 
     try {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When I use changelogithub.config.ts and configure the token, it cannot be obtained during the code execution, just like the following:

``` typescript
// changelogithub.config.ts

export default {
  token: 'xxx'
}

```

In the code, what is expected to be obtained is xxx, but what is actually obtained is an empty string.

And the reason for the problem is that: regardless of whether the token value is obtained from the CLI parameters, environment variables, or gh, args.token will overwrite the local configuration file, even though args.token is an empty string.




<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
