### PR TITLE
fix: refine user search query to include type and email context

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -65,7 +65,9 @@ export async function resolveAuthorInfo(options: ChangelogOptions, info: AuthorI
     return info
 
   try {
-    const data = await $fetch(`https://${options.baseUrlApi}/search/users?q=${encodeURIComponent(info.email)}`, {
+    // https://docs.github.com/en/search-github/searching-on-github/searching-users#search-only-users-or-organizations
+    const q = encodeURIComponent(`${info.email} type:user in:email`)
+    const data = await $fetch(`https://${options.baseUrlApi}/search/users?q=${q}`, {
       headers: getHeaders(options),
     })
     info.login = data.items[0].login


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

在 https://github.com/antfu-collective/ni/releases/tag/v24.3.0 发布信息中，获取到的用户信息是有误的。（[运行日志](https://github.com/antfu-collective/ni/actions/runs/13960586936/job/39081043830)

原因是使用邮件获取用户信息时没有过滤掉组织的情况。所以我提交一个 PR 将搜索添加了两个关键词，[GitHub 文档有说明](https://docs.github.com/en/search-github/searching-on-github/searching-users#search-only-users-or-organizations)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
